### PR TITLE
Update deprecated function-url-quotes option

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ module.exports = {
     "function-parentheses-newline-inside": "always-multi-line",
     "function-parentheses-space-inside": "never-single-line",
     "function-whitespace-after": "always",
-    "function-url-quotes": "double",
+    "function-url-quotes": "always",
     "indentation": 2,
     "max-empty-lines": 1,
     "max-line-length": [ 80, {


### PR DESCRIPTION
Fixes warning
> The 'double' option for 'function-url-quotes' has been deprecated, and will be removed in '7.0'. Instead, use the 'always' or 'never' options together with the 'string-quotes' rule. [stylelint]