### PR TITLE
Update deprecated number-zero-length-no-unit

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ module.exports = {
     "no-missing-eof-newline": true,
     "number-leading-zero": "always",
     "number-no-trailing-zeros": true,
-    "number-zero-length-no-unit": true,
+    "length-zero-no-unit": true,
     "property-no-vendor-prefix": true,
     "root-no-standard-properties": true,
     "rule-nested-empty-line-before": "always-multi-line",


### PR DESCRIPTION
Fixes warning from stylelint/stylelint#1421:

> `number-zero-length-no-unit` has been deprecated, and will be removed in `7.0`. Use `length-zero-no-unit` instead. See: <http://stylelint.io/user-guide/rules/length-zero-no-unit/>