### PR TITLE
Add stylelint-suitcss plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Head
 
+* Updated: `ava` to `0.18.2`
 * Updated: `eslint` to `3.17.0`
 * Updated: `eslint-config-stylelint` to `6.0.0`
 * Updated: `stylelint-order` to `0.3.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Head
 
+* Updated: `stylelint-order` to `0.3.0`
 * Added: `suitcss/root-no-standard-properties`
 * Added: `suitcss/selector-root-no-composition`
 * Added: `suitcss/custom-property-no-outside-root`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Head
+
+* Added: `suitcss/root-no-standard-properties`
+* Added: `suitcss/selector-root-no-composition`
+* Added: `suitcss/custom-property-no-outside-root`
+
 # 9.0.0
 
 * Removed: `root-no-standard-properties`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Head
 
+* Updated: `eslint` to `3.17.0`
+* Updated: `eslint-config-stylelint` to `6.0.0`
 * Updated: `stylelint-order` to `0.3.0`
 * Added: `suitcss/root-no-standard-properties`
 * Added: `suitcss/selector-root-no-composition`

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -89,7 +89,7 @@ test("no warnings with valid css", t => {
   .then(data => {
     const { errored, results } = data
     const { warnings } = results[0]
-    t.notOk(errored, "no errored")
+    t.falsy(errored, "no errored")
     t.is(warnings.length, 0, "flags no warnings")
   })
 })
@@ -102,7 +102,7 @@ test("a warning with invalid css", t => {
   .then(data => {
     const { errored, results } = data
     const { warnings } = results[0]
-    t.ok(errored, "errored")
+    t.truthy(errored, "errored")
     t.is(warnings.length, 1, "flags one warning")
     t.is(warnings[0].text, "Expected a leading zero (number-leading-zero)", "correct warning text")
   })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -84,7 +84,7 @@ const invalidCss = (
 test("no warnings with valid css", t => {
   return stylelint.lint({
     code: validCss,
-    config: config,
+    config,
   })
   .then(data => {
     const { errored, results } = data
@@ -97,7 +97,7 @@ test("no warnings with valid css", t => {
 test("a warning with invalid css", t => {
   return stylelint.lint({
     code: invalidCss,
-    config: config,
+    config,
   })
   .then(data => {
     const { errored, results } = data

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   "plugins": [
     "stylelint-order",
+    "stylelint-suitcss",
   ],
   "rules": {
     "at-rule-empty-line-before": [ "always", {
@@ -67,6 +68,9 @@ module.exports = {
     "selector-list-comma-space-before": "never",
     "selector-no-vendor-prefix": true,
     "selector-pseudo-element-colon-notation": "double",
+    "suitcss/custom-property-no-outside-root": true,
+    "suitcss/root-no-standard-properties": true,
+    "suitcss/selector-root-no-composition": true,
     "string-quotes": "double",
     "value-list-comma-newline-after": "always-multi-line",
     "value-list-comma-space-after": "always-single-line",

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
   ],
   "devDependencies": {
     "ava": "^0.13.0",
-    "eslint": "^2.4.0",
-    "eslint-config-stylelint": "^1.0.0",
+    "eslint": "^3.17.0",
+    "eslint-config-stylelint": "^6.0.0",
     "npmpub": "^3.0.1",
     "stylelint": "^7.8.0"
   },
@@ -39,7 +39,10 @@
   "eslintConfig": {
     "extends": [
       "stylelint"
-    ]
+    ],
+    "parserOptions": {
+      "sourceType": "module"
+    }
   },
   "dependencies": {
     "stylelint-order": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     ]
   },
   "dependencies": {
-    "stylelint-order": "^0.2.2",
+    "stylelint-order": "^0.3.0",
     "stylelint-suitcss": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "index.js"
   ],
   "devDependencies": {
-    "ava": "^0.13.0",
+    "ava": "^0.18.2",
     "eslint": "^3.17.0",
     "eslint-config-stylelint": "^6.0.0",
     "npmpub": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     ]
   },
   "dependencies": {
-    "stylelint-order": "^0.2.2"
+    "stylelint-order": "^0.2.2",
+    "stylelint-suitcss": "^1.0.0"
   }
 }


### PR DESCRIPTION
Adds back deprecated `:root` rules via `stylelint-suitcss`. Also updates various dependencies to latest versions.

@jeddy3 @giuseppeg 