### PR TITLE
upgrade stylelint to ^8.0.0, fixes #30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* Updated: `stylelint` to `8.0.0`
+
 # 11.0.0
 
 * Changed: `order/declaration-block-properties-alphabetical-order` to `order/properties-alphabetical-order`.

--- a/package.json
+++ b/package.json
@@ -24,10 +24,10 @@
     "eslint": "^3.17.0",
     "eslint-config-stylelint": "^6.0.0",
     "npmpub": "^3.0.1",
-    "stylelint": "^7.8.0"
+    "stylelint": "^8.0.0"
   },
   "peerDependencies": {
-    "stylelint": "^7.8.0"
+    "stylelint": "^8.0.0"
   },
   "scripts": {
     "ava": "ava --verbose \"__tests__/**/*.js\"",


### PR DESCRIPTION
@jeddy3 — I think this should work for #30. Tests pass; I'm going to link it in my local project to make sure I can upgrade my other stylelint packages that are want stylelint 8.0.0+ after this. LMK if there's anything else; I didn't see any contributing guidelines except in the main stylelint repo.