### PR TITLE
Extend stylelint peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "stylelint": "^15.6.0"
   },
   "peerDependencies": {
-    "stylelint": "^14.2.0"
+    "stylelint": "^14.2.0 || ^15.0.0"
   }
 }


### PR DESCRIPTION
It looks like stylelint was updated in the devDependencies without also updating the peerDependencies. This means that while this project is set up and tested using stylelint 15, projects that use this project can't use stylelint 15; they have to use 14.

This change extends the stylelint peerDependency version range to include 15. An alternative path would be to change the peerDependency to _only_ support stylelint 15, if you don't intend to continue testing with stylelint 14, although this would be a breaking change.